### PR TITLE
switch Mailer to use send over sendViaStorage

### DIFF
--- a/contracts/src/CrossChainMailbox.sol
+++ b/contracts/src/CrossChainMailbox.sol
@@ -31,7 +31,7 @@ contract CrossChainMailer is FeeCollector, ENSHelper {
             revert InsufficientFee(msg.value, fee);
         }
         string memory data = StringHelper.formatMessage(_message, msg.sender.balance, ENSHelper.getName(msg.sender));
-        telepathyRouter.sendViaStorage(_destinationChainId, _destinationMailbox, bytes(data));
+        telepathyRouter.send(_destinationChainId, _destinationMailbox, bytes(data));
     }
 }
 

--- a/contracts/test/CrossChainMailbox.t.sol
+++ b/contracts/test/CrossChainMailbox.t.sol
@@ -125,7 +125,6 @@ contract MailboxTest is Test, ENSHelper {
 
         assertEq(mailboxReceiver.messagesLength(), 1);
         string memory message = mailboxReceiver.messages(0);
-        console.log(message);
         assertEq(message, expectedMessage);
         assertEq(address(mailboxSender).balance, FEE);
 


### PR DESCRIPTION
[`send`](https://github.com/succinctlabs/telepathy-contracts/blob/fe9566b7837487dfb6d39e708a2c0bfb7c52ceaf/src/amb/interfaces/ITelepathy.sol#L22) is what we recommend going with in most cases, so demo should use that.